### PR TITLE
remove registration button from login page

### DIFF
--- a/src/components/LoginPage/LoginPage.js
+++ b/src/components/LoginPage/LoginPage.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { triggerLogin, formError, clearError } from '../../redux/actions/loginActions';
 
@@ -99,7 +98,6 @@ class LoginPage extends Component {
                 name="submit"
                 value="Log In"
               />
-              {/* <Link to="/register">Register</Link> */}
             </div>
           </form>
         </div>

--- a/src/components/LoginPage/LoginPage.js
+++ b/src/components/LoginPage/LoginPage.js
@@ -99,7 +99,7 @@ class LoginPage extends Component {
                 name="submit"
                 value="Log In"
               />
-              <Link to="/register">Register</Link>
+              {/* <Link to="/register">Register</Link> */}
             </div>
           </form>
         </div>


### PR DESCRIPTION
Now that we have our new way of handling users once the admin has logged in, we no longer need a registration button on the login landing page.